### PR TITLE
Fix logger object for APIs

### DIFF
--- a/binance_trade_bot/api_server.py
+++ b/binance_trade_bot/api_server.py
@@ -20,8 +20,8 @@ cors = CORS(app, resources={r"/api/*": {"origins": "*"}})
 socketio = SocketIO(app, cors_allowed_origins="*")
 
 
-logger = Logger("api_server")
 config = Config()
+logger = Logger(config, "api_server")
 db = Database(logger, config)
 
 


### PR DESCRIPTION
We do not pass the config object to the logger so it fails to initialize correctly.