### PR TITLE
Update inverse pair ratio when updating thresholds

### DIFF
--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -62,16 +62,18 @@ class AutoTrader:
         result = self.manager.buy_alt(pair.to_coin, self.config.BRIDGE)
         if result is not None:
             self.db.set_current_coin(pair.to_coin)
-            self.update_trade_threshold(pair.to_coin, result.price)
+            self.update_trade_threshold(pair, result.price)
             return result
 
         self.logger.info("Couldn't buy, going back to scouting mode...")
         return None
 
-    def update_trade_threshold(self, coin: Coin, coin_price: float):
+    def update_trade_threshold(self, newPair: Pair, coin_price: float):
         """
         Update all the coins with the threshold of buying the current held coin
         """
+
+        coin = newPair.to_coin
 
         if coin_price is None:
             self.logger.info("Skipping update... current coin {} not found".format(coin + self.config.BRIDGE))
@@ -79,6 +81,10 @@ class AutoTrader:
 
         session: Session
         with self.db.db_session() as session:
+            inverse_pair = session.query(Pair).filter((Pair.from_coin == newPair.to_coin) & (Pair.to_coin == newPair.from_coin)).one()
+            to_price = self.manager.get_ticker_price(inverse_pair.to_coin + self.config.BRIDGE)
+            inverse_pair.ratio = coin_price / to_price
+
             for pair in session.query(Pair).filter(Pair.to_coin == coin):
                 from_coin_price = self.manager.get_ticker_price(pair.from_coin + self.config.BRIDGE)
 


### PR DESCRIPTION
When updating the trade thresholds we should also update the inverse pair so that we do not end up immediately switching back to the previous.

Maybe we should only set it if the ratio is greater than what was already set?